### PR TITLE
Add validation and equality to entities

### DIFF
--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Bank.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Bank.java
@@ -1,6 +1,9 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -12,12 +15,18 @@ public class Bank {
     @Column(name = "id", nullable = false)
     private UUID id;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "name")
     private String name;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "inn")
     private String inn;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "bic")
     private String bic;
 
@@ -51,5 +60,18 @@ public class Bank {
 
     public void setBic(String bic) {
         this.bic = bic;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Bank bank = (Bank) o;
+        return Objects.equals(id, bank.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Client.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Client.java
@@ -1,6 +1,10 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -11,21 +15,34 @@ public class Client {
     @Column(name = "id")
     private UUID id;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "firstname")
     private String firstName;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "lastname")
     private String lastName;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "fathername")
     private String fatherName;
 
+    @NotNull
+    @Email
+    @Size(min = 1, max = 255)
     @Column(name = "email")
     private String email;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "pasportnumber")
     private String pasportNumber;
 
+    @NotNull
+    @Size(min = 1, max = 255)
     @Column(name = "phonenumber")
     private String phoneNumber;
 
@@ -87,5 +104,18 @@ public class Client {
 
     public String getName(){
         return getLastName() + " " + getFirstName() + " " + getFatherName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Client client = (Client) o;
+        return Objects.equals(id, client.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Credit.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/Credit.java
@@ -1,7 +1,9 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -13,28 +15,35 @@ public class Credit {
     @Column(name = "id")
     private UUID id;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "clientid")
     private Client client;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "banktid")
     private Bank bank;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "creditofferid")
     private CreditOffer creditOffer;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "paymentscheduleid")
     private PaymentSchedule paymentSchedule;
 
+    @NotNull
     @Column(name = "sum")
     private BigDecimal sum;
 
+    @NotNull
     @Column(name = "sumbody")
     private BigDecimal sumBody;
 
+    @NotNull
     @Column(name = "sumpercent")
     private BigDecimal sumPercent;
 
@@ -100,5 +109,18 @@ public class Credit {
 
     public void setSum(BigDecimal sum) {
         this.sum = sum;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Credit credit = (Credit) o;
+        return Objects.equals(id, credit.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/CreditOffer.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/CreditOffer.java
@@ -1,7 +1,9 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -13,13 +15,16 @@ public class CreditOffer {
     @Column(name = "id", nullable = false)
     private UUID id;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "bank_id")
     private Bank bank;
 
+    @NotNull
     @Column(name = "creditlimit")
     private BigDecimal creditLimit;
 
+    @NotNull
     @Column(name = "interestrate")
     private BigDecimal interestRate;
 
@@ -56,6 +61,20 @@ public class CreditOffer {
     }
 
     public String getName(){
-        return getBank().getName() + " " + getInterestRate() + " " + getCreditLimit();
+        String bankName = bank != null ? bank.getName() : "Unknown bank";
+        return bankName + " " + getInterestRate() + " " + getCreditLimit();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreditOffer that = (CreditOffer) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/PaymentMonth.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/PaymentMonth.java
@@ -1,8 +1,10 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -14,19 +16,24 @@ public class PaymentMonth {
     @Column(name = "id")
     private UUID id;
 
+    @NotNull
     @ManyToOne
     @JoinColumn(name = "paymentscheduleid")
     private PaymentSchedule paymentSchedule;
 
+    @NotNull
     @Column(name = "paymentdate")
     private LocalDate paymentDate;
 
+    @NotNull
     @Column(name = "paymentsum")
     private BigDecimal paymentSum;
 
+    @NotNull
     @Column(name = "sumbody")
     private BigDecimal sumBody;
 
+    @NotNull
     @Column(name = "sumpercent")
     private BigDecimal sumPercent;
 
@@ -87,5 +94,18 @@ public class PaymentMonth {
 
     public void setSumPercent(BigDecimal sumPercent) {
         this.sumPercent = sumPercent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentMonth that = (PaymentMonth) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/PaymentSchedule.java
+++ b/src/main/java/com/JuniorJavaDeveloper/banksystem/entity/PaymentSchedule.java
@@ -1,10 +1,11 @@
 package com.JuniorJavaDeveloper.banksystem.entity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -16,9 +17,11 @@ public class PaymentSchedule {
     @Column(name = "id", nullable = false)
     private UUID id;
 
+    @NotNull
     @Column(name = "datefirstpayment")
     private LocalDate dateFirstPayment;
 
+    @NotNull
     @Column(name = "dateendpayment")
     private LocalDate dateEndPayment;
 
@@ -55,5 +58,18 @@ public class PaymentSchedule {
 
     public void setDateEndPayment(LocalDate dateEndPayment) {
         this.dateEndPayment = dateEndPayment;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentSchedule that = (PaymentSchedule) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }


### PR DESCRIPTION
## Summary
- add bean validation annotations across entities
- guard null bank in `CreditOffer#getName`
- implement `equals`/`hashCode` for JPA entities

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4623b1060832ab5762956f7b2a53a