### PR TITLE
Add service and controller tests

### DIFF
--- a/src/test/java/com/JuniorJavaDeveloper/banksystem/controllers/BanksControllerTest.java
+++ b/src/test/java/com/JuniorJavaDeveloper/banksystem/controllers/BanksControllerTest.java
@@ -1,0 +1,72 @@
+package com.JuniorJavaDeveloper.banksystem.controllers;
+
+import com.JuniorJavaDeveloper.banksystem.entity.Bank;
+import com.JuniorJavaDeveloper.banksystem.forms.BankForm;
+import com.JuniorJavaDeveloper.banksystem.forms.FormManager;
+import com.JuniorJavaDeveloper.banksystem.services.CreditOfferService;
+import com.JuniorJavaDeveloper.banksystem.services.CreditService;
+import com.JuniorJavaDeveloper.banksystem.services.impl.BankServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BanksController.class)
+class BanksControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BankServiceImpl mainService;
+    @MockBean
+    private CreditOfferService creditOfferService;
+    @MockBean
+    private CreditService creditService;
+    @MockBean
+    private FormManager formManager;
+
+    @Test
+    void listAllReturnsIndexView() throws Exception {
+        BankForm form = new BankForm();
+        when(formManager.getBankForm()).thenReturn(form);
+        when(mainService.findAll()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/bank"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
+
+        verify(mainService).findAll();
+    }
+
+    @Test
+    void createBankRedirectsOnSuccess() throws Exception {
+        BankForm form = new BankForm();
+        form.setBank(new Bank());
+
+        mockMvc.perform(post("/bank").flashAttr("form", form))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/bank"));
+
+        verify(mainService).save(any(Bank.class));
+    }
+
+    @Test
+    void createBankReturnsServerErrorOnException() throws Exception {
+        BankForm form = new BankForm();
+        form.setBank(new Bank());
+        doThrow(new Exception("fail")).when(mainService).save(any(Bank.class));
+
+        mockMvc.perform(post("/bank").flashAttr("form", form))
+                .andExpect(status().is5xxServerError());
+    }
+}
+

--- a/src/test/java/com/JuniorJavaDeveloper/banksystem/controllers/CreditControllerTest.java
+++ b/src/test/java/com/JuniorJavaDeveloper/banksystem/controllers/CreditControllerTest.java
@@ -1,0 +1,53 @@
+package com.JuniorJavaDeveloper.banksystem.controllers;
+
+import com.JuniorJavaDeveloper.banksystem.forms.CreditForm;
+import com.JuniorJavaDeveloper.banksystem.forms.FormManager;
+import com.JuniorJavaDeveloper.banksystem.services.CreditOfferService;
+import com.JuniorJavaDeveloper.banksystem.services.creditmanager.CreditManager;
+import com.JuniorJavaDeveloper.banksystem.services.impl.BankServiceImpl;
+import com.JuniorJavaDeveloper.banksystem.services.impl.ClientServiceImpl;
+import com.JuniorJavaDeveloper.banksystem.services.impl.CreditServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(CreditController.class)
+class CreditControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreditServiceImpl mainService;
+    @MockBean
+    private BankServiceImpl bankService;
+    @MockBean
+    private CreditOfferService creditOfferService;
+    @MockBean
+    private ClientServiceImpl clientService;
+    @MockBean
+    private FormManager formManager;
+    @MockBean
+    private CreditManager creditManager;
+
+    @Test
+    void listAllReturnsIndexView() throws Exception {
+        CreditForm form = new CreditForm();
+        when(formManager.getCreditForm()).thenReturn(form);
+        when(mainService.findAll()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/credit"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
+    }
+}
+

--- a/src/test/java/com/JuniorJavaDeveloper/banksystem/services/impl/BankServiceImplTest.java
+++ b/src/test/java/com/JuniorJavaDeveloper/banksystem/services/impl/BankServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.JuniorJavaDeveloper.banksystem.services.impl;
+
+import com.JuniorJavaDeveloper.banksystem.entity.Bank;
+import com.JuniorJavaDeveloper.banksystem.repository.BankRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BankServiceImplTest {
+
+    @Mock
+    private BankRepository bankRepository;
+
+    private BankServiceImpl bankService;
+
+    @BeforeEach
+    void setUp() {
+        bankService = new BankServiceImpl(bankRepository);
+    }
+
+    @Test
+    void findAllReturnsBanks() {
+        List<Bank> banks = Arrays.asList(new Bank(), new Bank());
+        when(bankRepository.findAll()).thenReturn(banks);
+
+        List<Bank> result = bankService.findAll();
+
+        assertEquals(banks, result);
+        verify(bankRepository).findAll();
+    }
+
+    @Test
+    void saveDelegatesToRepository() {
+        Bank bank = new Bank();
+        bankService.save(bank);
+        verify(bankRepository).save(bank);
+    }
+
+    @Test
+    void deleteRemovesBank() {
+        UUID id = UUID.randomUUID();
+        Bank bank = new Bank();
+        when(bankRepository.getById(id)).thenReturn(bank);
+
+        bankService.delete(id);
+
+        verify(bankRepository).delete(bank);
+    }
+}
+

--- a/src/test/java/com/JuniorJavaDeveloper/banksystem/services/impl/CreditServiceImplTest.java
+++ b/src/test/java/com/JuniorJavaDeveloper/banksystem/services/impl/CreditServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.JuniorJavaDeveloper.banksystem.services.impl;
+
+import com.JuniorJavaDeveloper.banksystem.entity.*;
+import com.JuniorJavaDeveloper.banksystem.repository.CreditRepository;
+import com.JuniorJavaDeveloper.banksystem.repository.PaymentMonthRepository;
+import com.JuniorJavaDeveloper.banksystem.repository.PaymentScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreditServiceImplTest {
+
+    @Mock
+    private CreditRepository creditRepository;
+    @Mock
+    private PaymentScheduleRepository paymentScheduleRepository;
+    @Mock
+    private PaymentMonthRepository paymentMonthRepository;
+
+    private CreditServiceImpl creditService;
+
+    @BeforeEach
+    void setUp() {
+        creditService = new CreditServiceImpl(creditRepository, paymentScheduleRepository, paymentMonthRepository);
+    }
+
+    @Test
+    void saveStoresCreditWithScheduleAndMonths() throws Exception {
+        Credit credit = buildValidCredit();
+
+        creditService.save(credit);
+
+        verify(paymentScheduleRepository).save(credit.getPaymentSchedule());
+        verify(paymentMonthRepository, times(credit.getPaymentSchedule().getPaymentMonths().size())).save(any(PaymentMonth.class));
+        verify(creditRepository).save(credit);
+    }
+
+    @Test
+    void saveThrowsExceptionWhenClientMissing() {
+        Credit credit = new Credit();
+        credit.setBank(new Bank());
+        credit.setCreditOffer(new CreditOffer());
+        credit.setPaymentSchedule(new PaymentSchedule());
+
+        Exception ex = assertThrows(Exception.class, () -> creditService.save(credit));
+        assertTrue(ex.getMessage().toLowerCase().contains("client"));
+    }
+
+    private Credit buildValidCredit() {
+        Credit credit = new Credit();
+        credit.setClient(new Client());
+        credit.setBank(new Bank());
+        credit.setCreditOffer(new CreditOffer());
+
+        PaymentSchedule schedule = new PaymentSchedule();
+        List<PaymentMonth> months = Arrays.asList(new PaymentMonth(), new PaymentMonth());
+        schedule.setPaymentMonths(months);
+        credit.setPaymentSchedule(schedule);
+
+        return credit;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for BankServiceImpl and CreditServiceImpl including validation scenarios
- add MVC tests for BanksController and CreditController endpoints with success and error cases

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4623d1d60832aa07e69c73300c384